### PR TITLE
Set schedule for checking tags and building

### DIFF
--- a/.github/workflows/check-tags.yml
+++ b/.github/workflows/check-tags.yml
@@ -2,6 +2,9 @@ name: Check Tags
 
 on:
   workflow_dispatch:
+  schedule:
+    # Run every day at 12:00am and 12:00pm UTC
+    - cron: '0 0,12 * * *'
 
 jobs:
   check-tags:


### PR DESCRIPTION
This PR restores the daily schedule that used to be in place on Travis.

Because we can quickly check now if there are any tags to build before kicking off the build, we can run this more than once/day. As defined here, the built tags should no longer be more than 12 hours behind the latest – running at 12 am+pm UTC.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule