### PR TITLE
Add Keepalive

### DIFF
--- a/.github/workflows/.editorconfig
+++ b/.github/workflows/.editorconfig
@@ -1,0 +1,3 @@
+[*.yml]
+indent_size = 2
+indent_style = space

--- a/.github/workflows/check-tags.yml
+++ b/.github/workflows/check-tags.yml
@@ -62,3 +62,13 @@ jobs:
     if: needs.check-tags.outputs.tags-to-build != '[]'
     uses: ./.github/workflows/build.yml
     secrets: inherit
+
+  keepalive:
+    name: Keepalive
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      # Checkout is needed to determine if keepalive is necessary based on repo activity.
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@v2


### PR DESCRIPTION
Adds https://github.com/marketplace/actions/keepalive-workflow to prevent the scheduled `check-tags` workflow from stalling out due to repo inactivity.